### PR TITLE
rhel yum install bee - fix yaml indent issue

### DIFF
--- a/roles/bee/tasks/yum_install_bee.yml
+++ b/roles/bee/tasks/yum_install_bee.yml
@@ -4,8 +4,8 @@
 # adding the new repo file and using this same role to update
 - name: install Bacula Enteprise Edition postgresql
   yum:
-name: bacula-enterprise-postgresql
-state: latest
+    name: bacula-enterprise-postgresql
+    state: latest
   register: result
 - debug: msg="{{ result.stderr.split('\n') }}"
   when: result.stderr is defined


### PR DESCRIPTION
Goal: Fix yaml errors that cause rhel install of BEE from ansible galaxy collection to fail
Files touched: baculasystems/bacula_enterprise/roles/bee/tasks/yum_install_bee.yml
Change: Adds spaces to indent the  package name and state for bacula-enterprise-postgresql