### PR TITLE
feature/add-bweb-http-configuration

### DIFF
--- a/roles/bweb/README.md
+++ b/roles/bweb/README.md
@@ -1,3 +1,64 @@
 # Bacula Enterprise Collection for Ansible - baculasystems.bacula_enterprise
 
 # bweb role
+
+## [Example Playbook](#example-playbook)
+
+```yaml
+---
+- name: Converge
+  hosts: bweb_host
+  become: true
+  gather_facts: true
+
+  roles:
+    - role: bweb
+      bweb_server_bind: all
+```
+
+## [Role Variables](#role-variables)
+
+```yaml
+bweb_server_bind: localhost
+bweb_server_port: 9180
+
+# SSL - function default: false.
+# If true, the bweb_ssl_pem_file variable must be set to an pem file,
+# with private key and cert combined. The file must be set to mode 400 and
+# the ownership must be set to
+# bweb_server_username:bweb_server_groupname.
+bweb_ssl_enabled: false
+bweb_ssl_pem_file: /opt/bweb/etc/server.pem
+
+bweb_ssl_key_file: /etc/ssl/private/key.pem
+bweb_ssl_cert_file: /etc/ssl/certs/cert.pem
+
+# User and Group
+bweb_server_username: bacula
+bweb_server_groupname: bacula
+
+# Authentification
+# could be set to http_basic
+bweb_auth_type: none
+bweb_auth_file: /opt/bweb/etc/htpasswd.bweb
+```
+
+## [Requirements](#requirements)
+
+Installed bacula Bweb.
+
+## [Context](#context)
+
+## [Compatibility](#compatibility)
+
+The minimum version of Ansible required is 2.10, tests have been done to:
+
+- The previous version.
+- The current version.
+- The development version.
+
+## [Changelog](#changelog)
+
+## [License](#license)
+
+## [Author Information](#author-information)

--- a/roles/bweb/defaults/main.yml
+++ b/roles/bweb/defaults/main.yml
@@ -1,2 +1,27 @@
 ---
 dl_area: https://www.baculasystems.com/dl/@@customer@
+
+# Listening lighttpd service
+# bweb_server_bind: all is for listening on all network interfaces
+bweb_server_bind: localhost
+bweb_server_port: 9180
+
+# SSL - function default: false.
+# If true, the bacula_bweb_ssl_pem_file variable must be set to an pem file,
+# with private key and cert combined. The file must be set to mode 400 and
+# the ownership must be set to
+# bweb_server_username:bweb_server_groupname.
+bweb_ssl_enabled: false
+bweb_ssl_pem_file: /opt/bweb/etc/server.pem
+
+bweb_ssl_key_file: /etc/ssl/private/key.pem
+bweb_ssl_cert_file: /etc/ssl/certs/cert.pem
+
+# User and Group
+bweb_server_username: bacula
+bweb_server_groupname: bacula
+
+# Authentification
+# could be set to http_basic
+bweb_auth_type: none
+bweb_auth_file: /opt/bweb/etc/htpasswd.bweb

--- a/roles/bweb/handlers/main.yml
+++ b/roles/bweb/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+
+- name: Restart bweb
+  ansible.builtin.service:
+    name: "{{ bweb_service }}"
+    state: restarted

--- a/roles/bweb/tasks/AlmaLinux-8-64_install_bweb.yml
+++ b/roles/bweb/tasks/AlmaLinux-8-64_install_bweb.yml
@@ -3,6 +3,7 @@
 - include_tasks: yum_install_dependencies.yml
 - include_tasks: yum_install_bweb.yml
 - include_tasks: systemd_enable_and_start_bweb.yml
+- include_tasks: configure_bweb_http.yml
 - include_tasks: systemd_config_firewalld.yml
 - include_tasks: yum_list_packages_build.yml
 - include_tasks: check_connection.yml

--- a/roles/bweb/tasks/AlmaLinux-9-64_install_bweb.yml
+++ b/roles/bweb/tasks/AlmaLinux-9-64_install_bweb.yml
@@ -3,6 +3,7 @@
 - include_tasks: yum_install_dependencies.yml
 - include_tasks: yum_install_bweb.yml
 - include_tasks: systemd_enable_and_start_bweb.yml
+- include_tasks: configure_bweb_http.yml
 - include_tasks: systemd_config_firewalld.yml
 - include_tasks: yum_list_packages_build.yml
 - include_tasks: check_connection.yml

--- a/roles/bweb/tasks/CentOS-6-64_install_bweb.yml
+++ b/roles/bweb/tasks/CentOS-6-64_install_bweb.yml
@@ -2,5 +2,6 @@
 - include_tasks: yum-repository_add_repo_file.yml
 - include_tasks: yum_install_bweb.yml
 - include_tasks: service_enable_and_start_bweb.yml
+- include_tasks: configure_bweb_http.yml
 - include_tasks: list_packages_build.yml
 - include_tasks: check_connection.yml

--- a/roles/bweb/tasks/CentOS-7-64_install_bweb.yml
+++ b/roles/bweb/tasks/CentOS-7-64_install_bweb.yml
@@ -2,6 +2,7 @@
 - include_tasks: yum-repository_add_repo_file.yml
 - include_tasks: yum_install_bweb.yml
 - include_tasks: systemd_enable_and_start_bweb.yml
+- include_tasks: configure_bweb_http.yml
 - include_tasks: systemd_config_firewalld.yml
 - include_tasks: list_packages_build.yml
 - include_tasks: check_connection.yml

--- a/roles/bweb/tasks/CentOS-8-64_install_bweb.yml
+++ b/roles/bweb/tasks/CentOS-8-64_install_bweb.yml
@@ -2,6 +2,7 @@
 - include_tasks: yum-repository_add_repo_file.yml
 - include_tasks: yum_install_bweb.yml
 - include_tasks: systemd_enable_and_start_bweb.yml
+- include_tasks: configure_bweb_http.yml
 - include_tasks: systemd_config_firewalld.yml
 - include_tasks: list_packages_build.yml
 - include_tasks: check_connection.yml

--- a/roles/bweb/tasks/Debian-10-64_install_bweb.yml
+++ b/roles/bweb/tasks/Debian-10-64_install_bweb.yml
@@ -2,5 +2,6 @@
 - include_tasks: apt-repository_add_repo_file.yml
 - include_tasks: apt_install_bweb.yml
 - include_tasks: systemd_enable_and_start_bweb.yml
+- include_tasks: configure_bweb_http.yml
 - include_tasks: list_packages_build.yml
 - include_tasks: check_connection.yml

--- a/roles/bweb/tasks/Debian-11-64_install_bweb.yml
+++ b/roles/bweb/tasks/Debian-11-64_install_bweb.yml
@@ -2,5 +2,6 @@
 - include_tasks: apt-repository_add_repo_file.yml
 - include_tasks: apt_install_bweb.yml
 - include_tasks: systemd_enable_and_start_bweb.yml
+- include_tasks: configure_bweb_http.yml
 - include_tasks: list_packages_build.yml
 - include_tasks: check_connection.yml

--- a/roles/bweb/tasks/Debian-12-64_install_bweb.yml
+++ b/roles/bweb/tasks/Debian-12-64_install_bweb.yml
@@ -1,6 +1,7 @@
 ---
-    - include_tasks: apt-repository_add_repo_file.yml 
-    - include_tasks: apt_install_bweb.yml
-    - include_tasks: systemd_enable_and_start_bweb.yml
-    - include_tasks: apt_list_packages_build.yml
-    - include_tasks: check_connection.yml
+- include_tasks: apt-repository_add_repo_file.yml 
+- include_tasks: apt_install_bweb.yml
+- include_tasks: systemd_enable_and_start_bweb.yml
+- include_tasks: configure_bweb_http.yml
+- include_tasks: apt_list_packages_build.yml
+- include_tasks: check_connection.yml

--- a/roles/bweb/tasks/Debian-9-64_install_bweb.yml
+++ b/roles/bweb/tasks/Debian-9-64_install_bweb.yml
@@ -2,5 +2,6 @@
 - include_tasks: apt-repository_add_repo_file.yml
 - include_tasks: apt_install_bweb.yml
 - include_tasks: systemd_enable_and_start_bweb.yml
+- include_tasks: configure_bweb_http.yml
 - include_tasks: list_packages_build.yml
 - include_tasks: check_connection.yml

--- a/roles/bweb/tasks/OracleLinux-7-64_install_bweb.yml
+++ b/roles/bweb/tasks/OracleLinux-7-64_install_bweb.yml
@@ -3,5 +3,6 @@
 - include_tasks: yum_install_dependencies.yml
 - include_tasks: yum_install_bweb.yml
 - include_tasks: systemd_enable_and_start_bweb.yml
+- include_tasks: configure_bweb_http.yml
 - include_tasks: systemd_config_firewalld.yml
 - include_tasks: yum_list_packages_build.yml

--- a/roles/bweb/tasks/OracleLinux-8-64_install_bweb.yml
+++ b/roles/bweb/tasks/OracleLinux-8-64_install_bweb.yml
@@ -3,6 +3,7 @@
 - include_tasks: yum_install_dependencies.yml
 - include_tasks: yum_install_bweb.yml
 - include_tasks: systemd_enable_and_start_bweb.yml
+- include_tasks: configure_bweb_http.yml
 - include_tasks: systemd_config_firewalld.yml
 - include_tasks: yum_list_packages_build.yml
 - include_tasks: check_connection.yml

--- a/roles/bweb/tasks/OracleLinux-9-64_install_bweb.yml
+++ b/roles/bweb/tasks/OracleLinux-9-64_install_bweb.yml
@@ -3,6 +3,7 @@
 - include_tasks: yum_install_dependencies.yml
 - include_tasks: yum_install_bweb.yml
 - include_tasks: systemd_enable_and_start_bweb.yml
+- include_tasks: configure_bweb_http.yml
 - include_tasks: systemd_config_firewalld.yml
 - include_tasks: yum_list_packages_build.yml
 - include_tasks: check_connection.yml

--- a/roles/bweb/tasks/RedHat-8-64_install_bweb.yml
+++ b/roles/bweb/tasks/RedHat-8-64_install_bweb.yml
@@ -3,6 +3,7 @@
 - include_tasks: yum_install_dependencies.yml
 - include_tasks: yum_install_bweb.yml
 - include_tasks: systemd_enable_and_start_bweb.yml
+- include_tasks: configure_bweb_http.yml
 - include_tasks: systemd_config_firewalld.yml
 - include_tasks: yum_list_packages_build.yml
 - include_tasks: check_connection.yml

--- a/roles/bweb/tasks/RedHat-9-64_install_bweb.yml
+++ b/roles/bweb/tasks/RedHat-9-64_install_bweb.yml
@@ -3,6 +3,7 @@
 - include_tasks: yum_install_dependencies.yml
 - include_tasks: yum_install_bweb.yml
 - include_tasks: systemd_enable_and_start_bweb.yml
+- include_tasks: configure_bweb_http.yml
 - include_tasks: systemd_config_firewalld.yml
 - include_tasks: yum_list_packages_build.yml
 - include_tasks: check_connection.yml

--- a/roles/bweb/tasks/Rocky-8-64_install_bweb.yml
+++ b/roles/bweb/tasks/Rocky-8-64_install_bweb.yml
@@ -3,6 +3,7 @@
 - include_tasks: yum_install_dependencies.yml
 - include_tasks: yum_install_bweb.yml
 - include_tasks: systemd_enable_and_start_bweb.yml
+- include_tasks: configure_bweb_http.yml
 - include_tasks: systemd_config_firewalld.yml
 - include_tasks: yum_list_packages_build.yml
 - include_tasks: check_connection.yml

--- a/roles/bweb/tasks/Rocky-9-64_install_bweb.yml
+++ b/roles/bweb/tasks/Rocky-9-64_install_bweb.yml
@@ -3,6 +3,7 @@
 - include_tasks: yum_install_dependencies.yml
 - include_tasks: yum_install_bweb.yml
 - include_tasks: systemd_enable_and_start_bweb.yml
+- include_tasks: configure_bweb_http.yml
 - include_tasks: systemd_config_firewalld.yml
 - include_tasks: yum_list_packages_build.yml
 - include_tasks: check_connection.yml

--- a/roles/bweb/tasks/SLES-12-64_install_bweb.yml
+++ b/roles/bweb/tasks/SLES-12-64_install_bweb.yml
@@ -3,6 +3,7 @@
 - include_tasks: zypper_install_dependencies.yml
 - include_tasks: zypper_install_bweb.yml
 - include_tasks: systemd_enable_and_start_bweb.yml
+- include_tasks: configure_bweb_http.yml
 - include_tasks: sles_config_firewall.yml
 - include_tasks: list_packages_build.yml
 - include_tasks: check_connection.yml

--- a/roles/bweb/tasks/SLES-15-64_install_bweb.yml
+++ b/roles/bweb/tasks/SLES-15-64_install_bweb.yml
@@ -3,6 +3,7 @@
 - include_tasks: zypper_install_dependencies.yml
 - include_tasks: zypper_install_bweb.yml
 - include_tasks: systemd_enable_and_start_bweb.yml
+- include_tasks: configure_bweb_http.yml
 - include_tasks: sles_config_firewalld.yml
 - include_tasks: list_packages_build.yml
 - include_tasks: check_connection.yml

--- a/roles/bweb/tasks/Ubuntu-16-64_install_bweb.yml
+++ b/roles/bweb/tasks/Ubuntu-16-64_install_bweb.yml
@@ -2,5 +2,6 @@
 - include_tasks: apt-repository_add_repo_file.yml
 - include_tasks: apt_install_bweb.yml
 - include_tasks: systemd_enable_and_start_bweb.yml
+- include_tasks: configure_bweb_http.yml
 - include_tasks: list_packages_build.yml
 - include_tasks: check_connection.yml

--- a/roles/bweb/tasks/Ubuntu-18-64_install_bweb.yml
+++ b/roles/bweb/tasks/Ubuntu-18-64_install_bweb.yml
@@ -2,5 +2,6 @@
 - include_tasks: apt-repository_add_repo_file.yml
 - include_tasks: apt_install_bweb.yml
 - include_tasks: systemd_enable_and_start_bweb.yml
+- include_tasks: configure_bweb_http.yml
 - include_tasks: list_packages_build.yml
 - include_tasks: check_connection.yml

--- a/roles/bweb/tasks/Ubuntu-20-64_install_bweb.yml
+++ b/roles/bweb/tasks/Ubuntu-20-64_install_bweb.yml
@@ -2,5 +2,6 @@
 - include_tasks: apt-repository_add_repo_file.yml
 - include_tasks: apt_install_bweb.yml
 - include_tasks: systemd_enable_and_start_bweb.yml
+- include_tasks: configure_bweb_http.yml
 - include_tasks: list_packages_build.yml
 - include_tasks: check_connection.yml

--- a/roles/bweb/tasks/Ubuntu-22-64_install_bweb.yml
+++ b/roles/bweb/tasks/Ubuntu-22-64_install_bweb.yml
@@ -2,5 +2,6 @@
     - include_tasks: apt-repository_add_repo_file.yml 
     - include_tasks: apt_install_bweb.yml
     - include_tasks: systemd_enable_and_start_bweb.yml
+    - include_tasks: configure_bweb_http.yml
     - include_tasks: list_packages_build.yml
     - include_tasks: check_connection.yml

--- a/roles/bweb/tasks/Ubuntu-24-64_install_bweb.yml
+++ b/roles/bweb/tasks/Ubuntu-24-64_install_bweb.yml
@@ -2,5 +2,6 @@
 - include_tasks: apt-repository_add_repo_file.yml 
 - include_tasks: apt_install_bweb.yml
 - include_tasks: systemd_enable_and_start_bweb.yml
+- include_tasks: configure_bweb_http.yml
 - include_tasks: apt_list_packages_build.yml
 - include_tasks: check_connection.yml

--- a/roles/bweb/tasks/configure_bweb_http.yml
+++ b/roles/bweb/tasks/configure_bweb_http.yml
@@ -1,0 +1,39 @@
+---
+# bacula_bweb/tasks/main.yml
+
+- name: Set the bweb_config_file variable
+  ansible.builtin.set_fact:
+    bweb_config_file: "{{ __bweb_config_file }}"
+  when: bweb_config_file is not defined
+
+- name: Set the ssl input files
+  ansible.builtin.set_fact:
+    ssl_input_files:
+      - bweb_ssl_cert_file
+      - bweb_ssl_key_file
+  when: bweb_ssl_enabled
+
+- name: Generate ssl .pem file
+  ansible.builtin.template:
+    src: server.pem.j2
+    dest: "{{ bweb_ssl_pem_file }}"
+    mode: "0400"
+    owner: "{{ bweb_server_username }}"
+    group: "{{ bweb_server_groupname }}"
+  when:
+    - bweb_ssl_enabled
+    - bweb_ssl_pem_file is defined
+    - bweb_ssl_key_file is defined
+    - bweb_ssl_cert_file is defined
+  notify:
+    - Restart Bweb
+
+- name: Place Bweb httpd.conf
+  ansible.builtin.template:
+    src: "{{ bweb_config_file | basename }}.j2"
+    dest: "{{ bweb_config_file }}"
+    mode: "0644"
+    owner: root
+    group: root
+  notify:
+    - Restart Bweb

--- a/roles/bweb/templates/httpd.conf.j2
+++ b/roles/bweb/templates/httpd.conf.j2
@@ -1,0 +1,102 @@
+################################################################
+# lighttpd configuration example for bweb
+# bacula@localhost:~$ lighttpd -f script/httpd.conf
+# firefox http://localhost:9180
+################################################################
+
+{{ '#' if 'all' in bweb_server_bind else '' }}server.bind = "{{ bweb_server_bind }}"
+server.port = {{ bweb_server_port }}
+
+################################################################
+
+var.basedir = env.BWEBBASE
+var.logdir = env.BWEBLOG
+
+server.modules = ("mod_auth", "mod_cgi", "mod_alias", "mod_setenv",
+                  "mod_accesslog")
+server.document-root = basedir + "/html/"
+#server.errorlog = logdir + "/bweb-error.log"
+server.breakagelog = logdir + "/bweb-error.log"
+server.pid-file = logdir + "/bweb.pid"
+#accesslog.filename = logdir + "/bweb-access.log"
+cgi.assign = ( ".pl" => "/usr/bin/perl" )
+alias.url = ( "/cgi-bin/bweb/" => basedir + "/cgi/",
+              "/bweb/fv/" => "/opt/bweb/spool/",
+              "/bweb" => basedir + "/html/",
+               )
+
+setenv.add-environment = (
+  "PATH" => env.PATH,
+  "PERLLIB" => basedir + "/lib/",
+  "BWEBCONF" => basedir + "/bweb.conf",
+  "BWEBSESSION" => logdir + "/bweb/"
+)
+
+index-file.names = ( "index.html" )
+
+mimetype.assign = (
+".html" => "text/html",
+".gif" => "image/gif",
+".jpeg" => "image/jpeg",
+".jpg" => "image/jpeg",
+".png" => "image/png",
+".ico" => "image/x-icon",
+".css" => "text/css",
+".json" => "text/plain",
+".js" => "application/javascript",
+".svg" => "image/svg+xml",
+)
+
+################################################################
+# To enable SSL
+# openssl req   -x509 -nodes -days 365   -newkey rsa:1024 -keyout server.pem -out server.pem
+# chown bacula:bacula server.pem
+# chmod 400 server.pem
+
+{% if bweb_ssl_enabled %}
+ssl.engine = "enable"
+ssl.pemfile = "{{ bweb_ssl_pem_file }}"
+server.modules += ( "mod_openssl" )
+
+{% else %}
+#ssl.engine = "enable"
+#ssl.pemfile = "/opt/bweb/etc/server.pem"
+
+# On some versions of lighttpd, it is required to add the openssl module
+#server.modules += ( "mod_openssl" )
+{% endif %}
+
+################################################################
+# To enable Auth login http://redmine.lighttpd.net/projects/1/wiki/Docs_ModAuth
+# htpasswd -c /opt/bweb/etc/htpasswd.bweb
+
+## Uncomment this line if you use client registration by QR code or registration link
+# $HTTP["url"] !~ "^/cgi-bin/bweb/register.pl$" {
+
+## Uncomment below lines to enable HTTP Basic authentication
+{% if bweb_auth_type = 'http_basic' %}
+auth.backend = "htpasswd"
+auth.backend.htpasswd.userfile =  "{{ bweb_auth_file }}"
+auth.require = ( "/" =>
+        (
+        "method" => "basic",
+        "realm" => "Password protected area",
+        "require" => "valid-user"
+        )
+   )
+{% else %}
+#auth.backend = "htpasswd"
+#auth.backend.htpasswd.userfile =  "{{ bweb_auth_file }}"
+#auth.require = ( "/" =>
+#        (
+#        "method" => "basic",
+#        "realm" => "Password protected area",
+#        "require" => "valid-user"
+#        )
+#   )
+{% endif %}
+
+## Uncomment this line if you use client registration by QR code or registration link
+#}
+server.username  = "{{ bweb_server_username }}"
+server.groupname = "{{ bweb_server_groupname }}"

--- a/roles/bweb/templates/server.pem.j2
+++ b/roles/bweb/templates/server.pem.j2
@@ -1,0 +1,3 @@
+{% for i in ssl_input_files %}
+{{ lookup('file', i ) }}
+{% endfor %}

--- a/roles/bweb/vars/main.yml
+++ b/roles/bweb/vars/main.yml
@@ -1,2 +1,6 @@
 ---
 domain: example.com
+
+bweb_service: bweb
+
+__bweb_config_file: /opt/bweb/etc/httpd.conf


### PR DESCRIPTION
Make the bweb httpd.conf customizeable for:
- listening interface
- port definition
- ssl - certificate build (for pre-deployed cert and key file)
- htpasswd (for pre-deployed htpasswd)